### PR TITLE
Fixed bug preventing specific profiles from being accessed from namespaces

### DIFF
--- a/lib/backend/k8s/conversion.go
+++ b/lib/backend/k8s/conversion.go
@@ -17,7 +17,6 @@ package k8s
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	goerrors "errors"
 	"fmt"
 	"strings"
 
@@ -68,7 +67,7 @@ func (c converter) parsePolicyNameNamespace(name string) (string, error) {
 
 // parsePolicyNameNetworkPolicy extracts the Kubernetes Namespace and NetworkPolicy that backs the given Policy.
 func (c converter) parsePolicyNameNetworkPolicy(name string) (string, string, error) {
-	// Policies backed by NetworkPolicies have form "np.projectcalico.org/<ns_name>.<np_name>
+	// Policies backed by NetworkPolicies have form "np.projectcalico.org/<ns_name>.<np_name>"
 	if !strings.HasPrefix(name, "np.projectcalico.org/") {
 		// This is not backed by a Kubernetes NetworkPolicy.
 		return "", "", fmt.Errorf("Policy %s not backed by a NetworkPolicy", name)
@@ -84,11 +83,13 @@ func (c converter) parsePolicyNameNetworkPolicy(name string) (string, string, er
 
 // parseProfileName extracts the Namespace name from the given Profile name.
 func (c converter) parseProfileName(profileName string) (string, error) {
-	splits := strings.SplitN(profileName, ".", 2)
-	if len(splits) != 2 {
-		return "", goerrors.New(fmt.Sprintf("Invalid profile name: %s", profileName))
+	// Profile objects backed by Namespaces have form "ns.projectcalico.org/<ns_name>"
+	if !strings.HasPrefix(name, "ns.projectcalico.org/") {
+		// This is not backed by a Kubernetes Namespace.
+		return "", fmt.Errorf("Profile %s not backed by a Namespace", profileName)
 	}
-	return splits[1], nil
+
+	return strings.TrimPrefix(profileName, "ns.projectcalico.org/"), nil
 }
 
 // namespaceToProfile converts a Namespace to a Calico Profile.  The Profile stores

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -471,6 +471,7 @@ func (c *KubeClient) listProfiles(l model.ProfileListOptions) ([]*model.KVPair, 
 	if l.Name != "" {
 		kvp, err := c.getProfile(model.ProfileKey{Name: l.Name})
 		if err != nil {
+			log.Debugf("Error retrieving profile: %s", err)
 			return []*model.KVPair{}, nil
 		}
 		return []*model.KVPair{kvp}, nil


### PR DESCRIPTION
## Description
Fixed a bug where the calico prefix on namespaces was being used to query for profiles (which was invalid).  Also added a debug statement to display errors if there are issues with accessing profile information from the KDD.

## Tests
Set up Calico using the kubernetes datastore.
Ran `./calicoctl -l debug get profile ns.projectcalico.org/<name>` and verified profile information was returned
